### PR TITLE
SEO: meta tags, JSON-LD, sitemap og robots.txt

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1,3 +1,14 @@
+// ---------- seo ----------
+const GM_BASE_URL = 'https://oyvindholmstad.github.io/godmatsmak';
+
+function tidTilISO(tid) {
+  const t = tid.toLowerCase();
+  const h = t.match(/(\d+)\s*t/)?.[1];
+  const m = t.match(/(\d+)\s*min/)?.[1];
+  if (!h && !m) return undefined;
+  return `PT${h ? h + 'H' : ''}${m ? m + 'M' : ''}`;
+}
+
 // ---------- data ----------
 async function lastOppskrifter() {
   const manifest = await fetch('recipes/index.json').then(r => r.json());
@@ -733,6 +744,44 @@ function GMOppskrift({ recipes, id, onBack }) {
     setSteg({});
   }, [id]);
 
+  React.useEffect(() => {
+    document.title = `${r.navn} — God Matsmak`;
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'Recipe',
+      name: r.navn,
+      description: r.ingress,
+      recipeCategory: r.kategori,
+      recipeYield: `${r.porsjoner} porsjoner`,
+      recipeIngredient: r.ingredienser.flatMap(g => g.rader.map(rd => `${rd.m} ${rd.e} ${rd.n}`)),
+      recipeInstructions: r.steg.map((s, i) => ({
+        '@type': 'HowToStep',
+        position: i + 1,
+        name: s.t,
+        text: s.d,
+      })),
+      author: { '@type': 'Organization', name: 'God Matsmak' },
+    };
+    if (r.bilde) jsonLd.image = `${GM_BASE_URL}/${r.bilde}`;
+    const iso = tidTilISO(r.tid);
+    if (iso) jsonLd.totalTime = iso;
+
+    let el = document.getElementById('recipe-jsonld');
+    if (!el) {
+      el = document.createElement('script');
+      el.id = 'recipe-jsonld';
+      el.type = 'application/ld+json';
+      document.head.appendChild(el);
+    }
+    el.text = JSON.stringify(jsonLd);
+
+    return () => {
+      document.getElementById('recipe-jsonld')?.remove();
+      document.title = 'God Matsmak — Mat som smaker';
+    };
+  }, [r.id]);
+
   const toggle = (k) => setKrysset(p => ({ ...p, [k]: !p[k] }));
   const toggleSteg = (k) => setSteg(p => ({ ...p, [k]: !p[k] }));
   const neste = recipes.find(x => x.id !== r.id) || r;
@@ -907,6 +956,11 @@ function App() {
 
   React.useEffect(() => { localStorage.setItem('gm_side', side); }, [side]);
   React.useEffect(() => { localStorage.setItem('gm_oppskrift', oppskriftId); }, [oppskriftId]);
+
+  React.useEffect(() => {
+    if (side === 'forside') document.title = 'God Matsmak — Mat som smaker';
+    else if (side === 'oppskrifter') document.title = 'Alle oppskrifter — God Matsmak';
+  }, [side]);
 
   const openOppskrift = (id) => {
     setOppskriftId(id);

--- a/app.jsx
+++ b/app.jsx
@@ -1,5 +1,5 @@
 // ---------- seo ----------
-const GM_BASE_URL = 'https://oyvindholmstad.github.io/godmatsmak';
+const GM_BASE_URL = 'https://godmatsmak.no';
 
 function tidTilISO(tid) {
   const t = tid.toLowerCase();

--- a/index.html
+++ b/index.html
@@ -4,6 +4,38 @@
 <meta charset="UTF-8">
 <title>God Matsmak — Mat som smaker</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
+<meta name="author" content="God Matsmak">
+<link rel="canonical" href="https://oyvindholmstad.github.io/godmatsmak/">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://oyvindholmstad.github.io/godmatsmak/">
+<meta property="og:site_name" content="God Matsmak">
+<meta property="og:locale" content="nb_NO">
+<meta property="og:title" content="God Matsmak — Mat som smaker">
+<meta property="og:description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
+<meta property="og:image" content="https://oyvindholmstad.github.io/godmatsmak/recipes/images/kjottkaker.jpg">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="God Matsmak — Mat som smaker">
+<meta name="twitter:description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
+<meta name="twitter:image" content="https://oyvindholmstad.github.io/godmatsmak/recipes/images/kjottkaker.jpg">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "God Matsmak",
+  "url": "https://oyvindholmstad.github.io/godmatsmak/",
+  "description": "Oppskrifter som faktisk smaker",
+  "inLanguage": "nb",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://oyvindholmstad.github.io/godmatsmak/",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%23EFE8DA'/%3E%3Ccircle cx='32' cy='32' r='26' fill='%23EFE8DA' stroke='%233C2A1E' stroke-width='3'/%3E%3Ccircle cx='32' cy='32' r='20' fill='none' stroke='%233C2A1E' stroke-width='1' opacity='0.35'/%3E%3Ccircle cx='23' cy='27' r='7' fill='%238B2D1F'/%3E%3Ccircle cx='39' cy='25' r='7' fill='%238B2D1F'/%3E%3Ccircle cx='31' cy='40' r='7' fill='%238B2D1F'/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -6,32 +6,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
 <meta name="author" content="God Matsmak">
-<link rel="canonical" href="https://oyvindholmstad.github.io/godmatsmak/">
+<link rel="canonical" href="https://godmatsmak.no/">
 
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://oyvindholmstad.github.io/godmatsmak/">
+<meta property="og:url" content="https://godmatsmak.no/">
 <meta property="og:site_name" content="God Matsmak">
 <meta property="og:locale" content="nb_NO">
 <meta property="og:title" content="God Matsmak — Mat som smaker">
 <meta property="og:description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
-<meta property="og:image" content="https://oyvindholmstad.github.io/godmatsmak/recipes/images/kjottkaker.jpg">
+<meta property="og:image" content="https://godmatsmak.no/recipes/images/kjottkaker.jpg">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="God Matsmak — Mat som smaker">
 <meta name="twitter:description" content="Oppskrifter som faktisk smaker. Kjøttkaker, karrysuppe, grillspyd og mer — laget for kjøkkenet, ikke for Instagram.">
-<meta name="twitter:image" content="https://oyvindholmstad.github.io/godmatsmak/recipes/images/kjottkaker.jpg">
+<meta name="twitter:image" content="https://godmatsmak.no/recipes/images/kjottkaker.jpg">
 
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "WebSite",
   "name": "God Matsmak",
-  "url": "https://oyvindholmstad.github.io/godmatsmak/",
+  "url": "https://godmatsmak.no/",
   "description": "Oppskrifter som faktisk smaker",
   "inLanguage": "nb",
   "potentialAction": {
     "@type": "SearchAction",
-    "target": "https://oyvindholmstad.github.io/godmatsmak/",
+    "target": "https://godmatsmak.no/",
     "query-input": "required name=search_term_string"
   }
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://oyvindholmstad.github.io/godmatsmak/sitemap.xml
+Sitemap: https://godmatsmak.no/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://oyvindholmstad.github.io/godmatsmak/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://oyvindholmstad.github.io/godmatsmak/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <lastmod>2026-04-19</lastmod>
+  </url>
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://oyvindholmstad.github.io/godmatsmak/</loc>
+    <loc>https://godmatsmak.no/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <lastmod>2026-04-19</lastmod>


### PR DESCRIPTION
## Hva er gjort

- **`index.html`**: `<meta name="description">`, canonical URL, Open Graph-tags (tittel, beskrivelse, bilde), Twitter Card og statisk WebSite JSON-LD
- **`app.jsx`**: dynamisk `<title>` oppdateres ved navigasjon — forside, oppskriftsliste og per oppskrift. Recipe JSON-LD (schema.org) injiseres i `<head>` når en oppskrift åpnes, med ingredienser, fremgangsmåte, tilberedningstid og bilde
- **`robots.txt`**: tillater all crawling og peker til sitemap
- **`sitemap.xml`**: peker Google til roten

## Test

- [ ] Sjekk at tittelfanen endrer seg ved navigasjon
- [ ] Åpne en oppskrift → DevTools → Elements: `<script type="application/ld+json">` skal dukke opp i `<head>`
- [ ] Lim inn URL i [Open Graph debugger](https://developers.facebook.com/tools/debug/) etter deploy for å verifisere OG-tags
- [ ] Valider Recipe JSON-LD med [Google Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)