### PR TITLE
fix: neste oppskrift følger rekkefølgen i lista

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -820,7 +820,8 @@ function GMOppskrift({ recipes, id, onBack }) {
 
   const toggle = (k) => setKrysset(p => ({ ...p, [k]: !p[k] }));
   const toggleSteg = (k) => setSteg(p => ({ ...p, [k]: !p[k] }));
-  const neste = recipes.find(x => x.id !== r.id) || r;
+  const idx = recipes.findIndex(x => x.id === r.id);
+  const neste = recipes[(idx + 1) % recipes.length];
 
   return (
     <article>


### PR DESCRIPTION
## Problem

«Neste oppskrift»-knappen nederst på oppskriftssiden viste alltid den samme oppskriften — den første i lista som ikke var den du leste. `recipes.find(x => x.id !== r.id)` returnerer alltid det første treffet uansett hvor du er.

## Løsning

Finner indeksen til gjeldende oppskrift og henter `index + 1` med wrap-around, slik at man sykler gjennom hele samlingen i riktig rekkefølge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)