### PR TITLE
feat: valgfritt kilde-felt på oppskrifter

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -939,6 +939,15 @@ function GMOppskrift({ recipes, id, onBack }) {
           <GMLabel nr="§ D">Drikk til</GMLabel>
           <p style={{ fontFamily: '"Libre Caslon Text", serif', fontSize: mobil ? 22 : 30, lineHeight: 1.3, color: GM.ink, marginTop: 16, fontStyle: 'italic', letterSpacing: '-0.01em' }}>{r.par}</p>
         </div>
+        {r.kilde && (
+          <div style={{ gridColumn: mobil ? undefined : '1 / -1', borderTop: `1px solid ${GM.ink}18`, paddingTop: 20 }}>
+            <span style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, letterSpacing: '0.22em', color: GM.ink, opacity: 0.5 }}>KILDE: </span>
+            {r.kilde.lenke
+              ? <a href={r.kilde.lenke} target="_blank" rel="noopener noreferrer" style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, letterSpacing: '0.22em', color: GM.rust, textDecoration: 'none' }}>{r.kilde.tekst} →</a>
+              : <span style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, letterSpacing: '0.22em', color: GM.ink, opacity: 0.5 }}>{r.kilde.tekst}</span>
+            }
+          </div>
+        )}
       </section>
 
       <section style={{ padding: mobil ? '36px 16px' : '60px 40px', background: GM.ink, color: GM.cream }}>

--- a/recipes/svinecarnitas.json
+++ b/recipes/svinecarnitas.json
@@ -52,8 +52,5 @@
     { "t": "Server", "d": "Varm sausen om den har kjølnet, og hell den over det sprøstekte kjøttet rett før servering." }
   ],
   "servering": "Med varme tortillas, syltet rødløk, koriander, avokado og lime. Hver gjest bygger sin egen taco.",
-  "par": "Kald mexicansk lager som Modelo eller Pacifico, eller en margarita hvis det er fredag.",
-  "kilde": {
-    "tekst": "Serious Eats — J. Kenji López-Alt"
-  }
+  "par": "Kald mexicansk lager som Modelo eller Pacifico, eller en margarita hvis det er fredag."
 }

--- a/recipes/svinecarnitas.json
+++ b/recipes/svinecarnitas.json
@@ -54,7 +54,6 @@
   "servering": "Med varme tortillas, syltet rødløk, koriander, avokado og lime. Hver gjest bygger sin egen taco.",
   "par": "Kald mexicansk lager som Modelo eller Pacifico, eller en margarita hvis det er fredag.",
   "kilde": {
-    "tekst": "Serious Eats — J. Kenji López-Alt",
-    "lenke": "https://www.seriouseats.com/carnitas-recipe"
+    "tekst": "Serious Eats — J. Kenji López-Alt"
   }
 }

--- a/recipes/svinecarnitas.json
+++ b/recipes/svinecarnitas.json
@@ -52,5 +52,9 @@
     { "t": "Server", "d": "Varm sausen om den har kjølnet, og hell den over det sprøstekte kjøttet rett før servering." }
   ],
   "servering": "Med varme tortillas, syltet rødløk, koriander, avokado og lime. Hver gjest bygger sin egen taco.",
-  "par": "Kald mexicansk lager som Modelo eller Pacifico, eller en margarita hvis det er fredag."
+  "par": "Kald mexicansk lager som Modelo eller Pacifico, eller en margarita hvis det er fredag.",
+  "kilde": {
+    "tekst": "Serious Eats — J. Kenji López-Alt",
+    "lenke": "https://www.seriouseats.com/carnitas-recipe"
+  }
 }


### PR DESCRIPTION
## Hva er gjort

Legger til et valgfritt `kilde`-objekt i oppskrift-JSON-en for å kunne referere til hvor en oppskrift er hentet fra.

## Schema

```json
"kilde": {
  "tekst": "Serious Eats — J. Kenji López-Alt",
  "lenke": "https://www.seriouseats.com/carnitas-recipe"
}
```

- `kilde` er valgfritt — utelat feltet helt hvis oppskriften ikke har en kilde
- `tekst` er påkrevd hvis `kilde` er satt
- `lenke` er valgfritt — uten lenke vises bare teksten

## Visning

Vises diskret under «Drikk til»-seksjonen med `KILDE:` som etikett. Med lenke blir teksten klikkbar i rust-farge. Uten lenke vises teksten dempet.

## Eksempel

`svinecarnitas.json` er oppdatert med et eksempel på kilde med lenke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)