### PR TITLE
fix: bruk riktig terminologi på kategorier

### DIFF
--- a/recipes/fiskegrateng-sprotopp.json
+++ b/recipes/fiskegrateng-sprotopp.json
@@ -3,7 +3,7 @@
   "nr": "№ 02",
   "navn": "Fiskegrateng med sprø topp",
   "undertittel": "Kantina på skolen tok feil — dette er noe helt annet",
-  "kategori": "Hovedrett",
+  "kategori": "middagsmak",
   "tid": "1 t 10 min",
   "porsjoner": 4,
   "vanskelighet": "Middels",

--- a/recipes/grillspyd-cracksaus.json
+++ b/recipes/grillspyd-cracksaus.json
@@ -3,7 +3,7 @@
   "nr": "№ 03",
   "navn": "Grillspyd med crack-saus",
   "undertittel": "Den sausen du kommer til å dyppe alt i, også det som ikke trenger dipp",
-  "kategori": "Hovedrett",
+  "kategori": "middagsmak",
   "tid": "3 t (med marinering)",
   "porsjoner": 4,
   "vanskelighet": "Middels",

--- a/recipes/kjottkaker-brun-saus.json
+++ b/recipes/kjottkaker-brun-saus.json
@@ -3,7 +3,7 @@
   "nr": "№ 01",
   "navn": "Kjøttkaker i brun saus",
   "undertittel": "Den som smaker som mormor, bare litt frekkere",
-  "kategori": "Hovedrett",
+  "kategori": "middagsmak",
   "tid": "55 min",
   "porsjoner": 4,
   "vanskelighet": "Enkel",

--- a/recipes/kokoskarry-nudler.json
+++ b/recipes/kokoskarry-nudler.json
@@ -3,7 +3,7 @@
   "nr": "№ 04",
   "navn": "Kokoskarry-suppe med nudler",
   "undertittel": "Femten minutter til middag som smaker som restaurant",
-  "kategori": "Suppe",
+  "kategori": "suppesmak",
   "tid": "15 min",
   "porsjoner": 3,
   "vanskelighet": "Enkel",

--- a/recipes/svinecarnitas.json
+++ b/recipes/svinecarnitas.json
@@ -3,7 +3,7 @@
   "nr": "№ 05",
   "navn": "Svinecarnitas",
   "undertittel": "Langtidskokt svin som blir sprø på toppen og mør inni",
-  "kategori": "Hovedrett",
+  "kategori": "middagsmak",
   "tid": "3 t 30 min",
   "porsjoner": 4,
   "vanskelighet": "Middels",


### PR DESCRIPTION
## Hva er gjort

Erstatter generiske matlagingstermer med God Matsmaks egne kategoribetegnelser på tvers av alle oppskrifter:

| Før | Etter |
|-----|-------|
| Hovedrett | middagsmak |
| Suppe | suppesmak |

Berørte oppskrifter: kjottkaker-brun-saus, fiskegrateng-sprotopp, svinecarnitas, grillspyd-cracksaus, kokoskarry-nudler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)